### PR TITLE
Batch insert using insertmany() added

### DIFF
--- a/Results - Oracle/Single vs Bulk Insert.md
+++ b/Results - Oracle/Single vs Bulk Insert.md
@@ -1,0 +1,8 @@
+### When 500,000 Records were inserted
+
+##### File Name : main_doc.json, File Size : 12kB
+
+Time taken for row by row insert : 3h 33m 42s 618ms
+
+Time taken for bulk insert : 14m 41s 544ms
+

--- a/Results - Oracle/singleInsert.md
+++ b/Results - Oracle/singleInsert.md
@@ -1,6 +1,0 @@
-### When 500,000 Records were inserted
-
-##### File Name : main_doc.json, File Size : 12kB
-
-Time for row by row inserts : 3h 33m 42s 618ms
-


### PR DESCRIPTION
- When one loop was run for 500k documents at once, an error occurred array size too large and thus, 2 loops were run